### PR TITLE
requirements: Fix build on Python 3.12.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.5.3
-numpy==1.24.3
+numpy==1.26.2
 pdftotext==2.2.2


### PR DESCRIPTION
Numpy 1.24 build is broken on Python 3.12 [1]. 1.26.2 seems to be the first version that fixes it.

[1] https://github.com/numpy/numpy/issues/23808